### PR TITLE
Add Eisenhower matrix view

### DIFF
--- a/app/assets/stylesheets/tasks.css.scss
+++ b/app/assets/stylesheets/tasks.css.scss
@@ -1,3 +1,13 @@
 // Place all the styles related to the tasks controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+.matrix {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  gap: 1em;
+}
+.quadrant {
+  border: 1px solid #ccc;
+  padding: 0.5em;
+}

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,11 @@
 class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
+  # Display tasks organised in the Eisenhower matrix
+  def matrix
+    @tasks = Task.all.group_by(&:quadrant)
+  end
+
   # GET /tasks
   # GET /tasks.json
   def index

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,28 @@
 class Task < ActiveRecord::Base
+  # Determine if the task is urgent based on the due date
+  def urgent?
+    due.present? && due <= 2.days.from_now
+  end
+
+  # Determine if the task is important based on the importance score
+  def important?
+    importance.present? && importance > 5
+  end
+
+  # Map the task to one of the four Eisenhower matrix quadrants
+  # 1: important & urgent
+  # 2: important & not urgent
+  # 3: not important & urgent
+  # 4: not important & not urgent
+  def quadrant
+    if important? && urgent?
+      1
+    elsif important?
+      2
+    elsif urgent?
+      3
+    else
+      4
+    end
+  end
 end

--- a/app/views/graph/index.html.erb
+++ b/app/views/graph/index.html.erb
@@ -1,3 +1,4 @@
 <h1>Look what you have to do</h1>
+<p><%= link_to 'View Matrix', matrix_path %></p>
 <pre>
-<p><%= @tasks.to_json %>
+<%= @tasks.to_json %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -31,3 +31,5 @@
 <br>
 
 <%= link_to 'New Task', new_task_path %>
+|
+<%= link_to 'Eisenhower Matrix', matrix_path %>

--- a/app/views/tasks/matrix.html.erb
+++ b/app/views/tasks/matrix.html.erb
@@ -1,0 +1,36 @@
+<h1>Eisenhower Matrix</h1>
+
+<div class="matrix">
+  <div class="quadrant q1">
+    <h2>Important &amp; Urgent</h2>
+    <ul>
+      <% (@tasks[1] || []).each do |task| %>
+        <li><%= link_to task.name, task %></li>
+      <% end %>
+    </ul>
+  </div>
+  <div class="quadrant q2">
+    <h2>Important &amp; Not Urgent</h2>
+    <ul>
+      <% (@tasks[2] || []).each do |task| %>
+        <li><%= link_to task.name, task %></li>
+      <% end %>
+    </ul>
+  </div>
+  <div class="quadrant q3">
+    <h2>Not Important &amp; Urgent</h2>
+    <ul>
+      <% (@tasks[3] || []).each do |task| %>
+        <li><%= link_to task.name, task %></li>
+      <% end %>
+    </ul>
+  </div>
+  <div class="quadrant q4">
+    <h2>Not Important &amp; Not Urgent</h2>
+    <ul>
+      <% (@tasks[4] || []).each do |task| %>
+        <li><%= link_to task.name, task %></li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   get 'graph/index'
 
+  get 'matrix', to: 'tasks#matrix'
+
   resources :tasks
 
   root 'graph#index'


### PR DESCRIPTION
## Summary
- implement `urgent?`, `important?`, and `quadrant` helpers in `Task`
- add a `matrix` action and route to display tasks in an Eisenhower matrix
- provide a new view for matrix with simple quadrant layout
- style matrix layout with CSS
- link to matrix from graph and task index pages

## Testing
- `bundle exec rake test` *(fails: Could not find rails-4.1.5, sqlite3-1.3.9, ...)*

------
https://chatgpt.com/codex/tasks/task_e_686bc275dcd8832994c7ca78a091b6a2